### PR TITLE
Debug dumps no longer contain session keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ debug arguments:
   --short-debug         Shorten video length to just a few minutes for debugging
 
   --debug, --debug-dumps
-                        Enable debugging -- WARNING: will dump session keys to disk
+                        Enable debugging -- adds extra logging and debug dumps in the ./dumps folder
 ```
 
 ### Streams to choose from

--- a/nhltv_lib/arguments.py
+++ b/nhltv_lib/arguments.py
@@ -81,7 +81,7 @@ def parse_args(args: List[str]) -> argparse.Namespace:
         "--debug-dumps",
         dest="debug_dumps_enabled",
         action="store_true",
-        help="Enable debugging -- WARNING: will dump session keys to disk",
+        help="Enable debugging -- adds extra logging and debug dumps in the ./dumps folder",
     )
 
     parser.add_argument(

--- a/nhltv_lib/common.py
+++ b/nhltv_lib/common.py
@@ -48,7 +48,7 @@ def debug_dumps_enabled() -> bool:
     return arguments.debug_dumps_enabled
 
 
-def debug_dump_json(content: Union[dict, list], caller: str = "") -> None:
+def debug_dump_json(content: dict, caller: str = "") -> None:
     filename = f"dumps/{caller}_{datetime.now().isoformat()}.json"
 
     # clean up sensitive information from the dumps
@@ -73,7 +73,7 @@ def debug_dump_pickle(content: Union[dict, list], caller: str = "") -> None:
         pickle.dump(content, f)
 
 
-def dump_json_if_debug_enabled(content: Union[List, Dict]) -> None:
+def dump_json_if_debug_enabled(content: dict) -> None:
     caller_name = inspect.getouterframes(inspect.currentframe(), 2)[1][3]
     if debug_dumps_enabled():
         debug_dump_json(content, caller=caller_name)

--- a/nhltv_lib/common.py
+++ b/nhltv_lib/common.py
@@ -50,6 +50,19 @@ def debug_dumps_enabled() -> bool:
 
 def debug_dump_json(content: Union[dict, list], caller: str = "") -> None:
     filename = f"dumps/{caller}_{datetime.now().isoformat()}.json"
+
+    # clean up sensitive information from the dumps
+    if content.get("session_key", False):
+        content["session_key"] = "REDACTED"
+    if (
+        content.get("session_info", {})
+        .get("sessionAttributes", [{}])[0]
+        .get("attributeValue", False)
+    ):
+        content["session_info"]["sessionAttributes"][0][
+            "attributeValue"
+        ] = "REDACTED"
+
     with open(filename, "w") as f:
         json.dump(content, f)
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-VERSION = "2.1.2"
+VERSION = "2.1.3"
 
 setup(
     name="nhltv",

--- a/tests/unit/test_common.py
+++ b/tests/unit/test_common.py
@@ -105,6 +105,39 @@ def test_dump_json(mocker, mock_datetime, mock_open):
     mj.assert_called_once_with({"foo": "bar"}, mock_open())
 
 
+def test_dump_json_erases_sesskey(mocker, mock_datetime, mock_open):
+    mj = mocker.patch("json.dump")
+    debug_dump_json({"foo": "bar", "session_key": "bar"})
+    mock_open.assert_called_once_with(
+        f"dumps/_{mock_datetime.isoformat()}.json", "w"
+    )
+    mj.assert_called_once_with(
+        {"foo": "bar", "session_key": "REDACTED"}, mock_open()
+    )
+
+
+def test_dump_json_erases_mediaauth(mocker, mock_datetime, mock_open):
+    mj = mocker.patch("json.dump")
+    debug_dump_json(
+        {
+            "foo": "bar",
+            "session_info": {"sessionAttributes": [{"attributeValue": "bar"}]},
+        }
+    )
+    mock_open.assert_called_once_with(
+        f"dumps/_{mock_datetime.isoformat()}.json", "w"
+    )
+    mj.assert_called_once_with(
+        {
+            "foo": "bar",
+            "session_info": {
+                "sessionAttributes": [{"attributeValue": "REDACTED"}]
+            },
+        },
+        mock_open(),
+    )
+
+
 def test_dump_json_w_caller(mocker, mock_datetime, mock_open):
     mj = mocker.patch("json.dump")
     debug_dump_json({"foo": "bar"}, caller="baz")


### PR DESCRIPTION
So that they can be shared without having any really sensitive information in them, should be useful for debugging purposes